### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-build-docker.yml
+++ b/.github/workflows/push-build-docker.yml
@@ -40,7 +40,7 @@ jobs:
           property: 'version'
           value: ${{ steps.bump_version.outputs.next-version }}
       - name: Publish to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: masseyhacks/masseyhacks-verification-bot
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore